### PR TITLE
Improve portfolio look and feel with 7 UI enhancements

### DIFF
--- a/src/app/portfolio.component.css
+++ b/src/app/portfolio.component.css
@@ -59,28 +59,65 @@
 }
 
 .portfolio {
-  max-width: 900px;
+  max-width: 1200px;
   margin: 0 auto;
   padding: 3rem 1rem;
   display: grid;
+  grid-template-columns: 1fr 1fr;
   gap: 1.1rem;
   position: relative;
   z-index: 1;
 }
+
+.top-nav       { grid-column: 1 / -1; }
+.hero          { grid-column: 1; }
+#skills        { grid-column: 2; }
+#experience    { grid-column: 1; }
+#projects      { grid-column: 2; }
+#education     { grid-column: 1; }
+#contact       { grid-column: 2; }
 
 .top-nav {
   position: sticky;
   top: 0.65rem;
   z-index: 50;
   display: flex;
-  flex-wrap: wrap;
+  align-items: center;
   gap: 0.5rem;
-  padding: 0.75rem;
+  padding: 0.5rem 0.75rem;
   border-radius: 10px;
   background: var(--nav-bg);
   border: 1px solid var(--card-border);
   backdrop-filter: blur(10px);
   box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.03), 0 10px 26px var(--card-shadow);
+}
+
+.nav-brand {
+  font-weight: 800;
+  font-size: 0.95rem;
+  letter-spacing: 0.06em;
+  color: #fff !important;
+  background: linear-gradient(135deg, var(--accent-soft), var(--accent));
+  border: none !important;
+  border-radius: 7px !important;
+  padding: 0.3rem 0.6rem !important;
+  margin-right: 0.25rem;
+  flex-shrink: 0;
+  text-decoration: none;
+  transition: filter 0.2s ease;
+}
+
+.nav-brand:hover {
+  filter: brightness(1.12);
+  background: linear-gradient(135deg, var(--accent-soft), var(--accent)) !important;
+  color: #fff !important;
+}
+
+.nav-links {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  flex-wrap: wrap;
 }
 
 .top-nav a {
@@ -202,6 +239,17 @@
   scroll-margin-top: 5.8rem;
 }
 
+.section-anchor.reveal {
+  opacity: 0;
+  transform: translateY(22px);
+  transition: opacity 0.55s ease, transform 0.55s ease;
+}
+
+.section-anchor.reveal.visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
 .hero {
   text-align: left;
   background: var(--card-bg);
@@ -209,6 +257,59 @@
   padding: 2rem;
   border: 1px solid var(--card-border);
   box-shadow: 0 14px 36px var(--card-shadow), inset 0 0 0 1px rgba(255, 255, 255, 0.02);
+}
+
+.hero-inner {
+  display: flex;
+  align-items: flex-start;
+  gap: 1.75rem;
+}
+
+.hero-text {
+  flex: 1;
+  min-width: 0;
+}
+
+.avatar-wrap {
+  flex-shrink: 0;
+}
+
+.avatar-photo,
+.avatar-initials {
+  width: 110px;
+  height: 110px;
+  border-radius: 50%;
+  border: 2px solid var(--card-border);
+  box-shadow: 0 0 18px color-mix(in srgb, var(--accent) 35%, transparent);
+}
+
+.avatar-photo {
+  object-fit: cover;
+  display: block;
+}
+
+.avatar-initials {
+  background: linear-gradient(135deg, var(--accent-soft), var(--accent));
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.9rem;
+  font-weight: 800;
+  color: #fff;
+  letter-spacing: 0.05em;
+}
+
+.cursor {
+  display: inline-block;
+  color: var(--accent);
+  font-weight: 300;
+  margin-left: 1px;
+  animation: blink 0.8s step-end infinite;
+}
+
+@keyframes blink {
+  from, to { opacity: 1; }
+  50%       { opacity: 0; }
 }
 
 .intro {
@@ -252,7 +353,6 @@ h1 {
   margin-top: 1rem;
   line-height: 1.6;
   color: var(--text-muted);
-  max-width: 70ch;
 }
 
 .resume-download {
@@ -299,15 +399,173 @@ li {
   line-height: 1.5;
 }
 
-@media (max-width: 600px) {
+.timeline {
+  position: relative;
+  padding-left: 1.6rem;
+}
+
+.timeline::before {
+  content: '';
+  position: absolute;
+  left: 0.42rem;
+  top: 0.4rem;
+  bottom: 0.4rem;
+  width: 2px;
+  background: linear-gradient(to bottom, var(--accent), var(--accent-soft));
+  border-radius: 1px;
+  opacity: 0.6;
+}
+
+.timeline-item {
+  position: relative;
+  padding-bottom: 1.6rem;
+}
+
+.timeline-item:last-child {
+  padding-bottom: 0;
+}
+
+.timeline-dot {
+  position: absolute;
+  left: -1.6rem;
+  top: 0.32rem;
+  width: 0.7rem;
+  height: 0.7rem;
+  border-radius: 50%;
+  background: var(--accent);
+  border: 2px solid var(--card-bg);
+  box-shadow: 0 0 8px color-mix(in srgb, var(--accent) 70%, transparent);
+}
+
+.timeline-content {
+  padding-left: 0.25rem;
+}
+
+.timeline-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.timeline-role {
+  font-weight: 700;
+  font-size: 0.95rem;
+  color: var(--text-main);
+}
+
+.timeline-dates {
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.03em;
+  white-space: nowrap;
+  color: var(--intro-color);
+  background: color-mix(in srgb, var(--intro-color) 12%, transparent);
+  border: 1px solid color-mix(in srgb, var(--intro-color) 30%, transparent);
+  border-radius: 999px;
+  padding: 0.15rem 0.6rem;
+}
+
+.timeline-company {
+  font-size: 0.83rem;
+  color: var(--text-muted);
+  margin: 0.2rem 0 0.5rem;
+}
+
+.timeline-desc {
+  margin: 0;
+  font-size: 0.88rem;
+  line-height: 1.6;
+  color: var(--text-muted);
+}
+
+.contact-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+}
+
+.contact-list li {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin: 0;
+}
+
+.contact-icon {
+  width: 1.1rem;
+  height: 1.1rem;
+  color: var(--intro-color);
+  flex-shrink: 0;
+}
+
+.contact-list a {
+  color: var(--text-main);
+  text-decoration: none;
+  font-size: 0.9rem;
+  transition: color 0.18s ease;
+  word-break: break-all;
+}
+
+.contact-list a:hover {
+  color: var(--accent);
+}
+
+.contact-list span {
+  font-size: 0.9rem;
+  color: var(--text-muted);
+}
+
+.skill-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-top: 0.25rem;
+}
+
+.chip {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.28rem 0.75rem;
+  border-radius: 999px;
+  font-size: 0.8rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  white-space: nowrap;
+  background: color-mix(in srgb, var(--accent-soft) 16%, transparent);
+  border: 1px solid color-mix(in srgb, var(--accent-soft) 40%, transparent);
+  color: var(--text-main);
+  transition: background 0.18s ease, border-color 0.18s ease;
+}
+
+.chip:hover {
+  background: color-mix(in srgb, var(--accent-soft) 28%, transparent);
+  border-color: color-mix(in srgb, var(--accent-soft) 65%, transparent);
+}
+
+@media (max-width: 768px) {
   .portfolio {
+    grid-template-columns: 1fr;
     padding: 2rem 0.75rem;
+  }
+
+  .top-nav, .hero, #skills, #experience, #projects, #education, #contact {
+    grid-column: 1;
   }
 
   .top-nav {
     gap: 0.4rem;
-    padding: 0.65rem;
+    padding: 0.5rem 0.65rem;
     top: 0.4rem;
+    flex-wrap: wrap;
+  }
+
+  .nav-links {
+    flex-wrap: wrap;
   }
 
   .top-nav a {
@@ -329,6 +587,12 @@ li {
   .hero,
   .card {
     padding: 1.25rem;
+  }
+
+  .hero-inner {
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
   }
 
   h1 {

--- a/src/app/portfolio.component.html
+++ b/src/app/portfolio.component.html
@@ -1,11 +1,15 @@
 <main class="portfolio">
   <nav class="top-nav" [attr.aria-label]="'nav.ariaLabel' | translate">
-    <a href="#about">{{ 'nav.about' | translate }}</a>
-    <a href="#skills">{{ 'nav.skills' | translate }}</a>
-    <a href="#experience">{{ 'nav.experience' | translate }}</a>
-    <a href="#projects">{{ 'nav.projects' | translate }}</a>
-    <a href="#education">{{ 'nav.education' | translate }}</a>
-    <a href="#contact">{{ 'nav.contact' | translate }}</a>
+    <a href="#about" class="nav-brand" aria-label="Javier Lopez – home">JL</a>
+
+    <div class="nav-links">
+      <a href="#about">{{ 'nav.about' | translate }}</a>
+      <a href="#skills">{{ 'nav.skills' | translate }}</a>
+      <a href="#experience">{{ 'nav.experience' | translate }}</a>
+      <a href="#projects">{{ 'nav.projects' | translate }}</a>
+      <a href="#education">{{ 'nav.education' | translate }}</a>
+      <a href="#contact">{{ 'nav.contact' | translate }}</a>
+    </div>
 
     <div class="nav-controls">
       <div class="lang-switch" role="group" [attr.aria-label]="'nav.language' | translate">
@@ -44,39 +48,63 @@
   </nav>
 
   <section id="about" class="hero section-anchor">
-    <p class="intro">{{ 'hero.intro' | translate }}</p>
-    <h1>Javier Lopez</h1>
-    <p class="role">{{ 'hero.role' | translate }}</p>
-    <p class="summary">{{ 'hero.summary1' | translate }}</p>
-    <p class="summary">{{ 'hero.summary2' | translate }}</p>
-    <a class="resume-download" href="/Javier%20Lopez%20-%20Resume.pdf" download="Javier Lopez - Resume.pdf">
-      {{ 'resume.download' | translate }}
-    </a>
+    <div class="hero-inner">
+      <div class="avatar-wrap">
+        <img class="avatar-photo" src="/avatar.jpg" alt="Javier Lopez" *ngIf="!avatarMissing" (error)="avatarMissing = true">
+        <div class="avatar-initials" *ngIf="avatarMissing">JL</div>
+      </div>
+      <div class="hero-text">
+        <p class="intro">{{ 'hero.intro' | translate }}</p>
+        <h1>Javier Lopez</h1>
+        <p class="role">{{ displayedRole }}<span class="cursor">|</span></p>
+        <p class="summary">{{ 'hero.summary1' | translate }}</p>
+        <p class="summary">{{ 'hero.summary2' | translate }}</p>
+        <a class="resume-download" href="/Javier%20Lopez%20-%20Resume.pdf" download="Javier Lopez - Resume.pdf">
+          {{ 'resume.download' | translate }}
+        </a>
+      </div>
+    </div>
   </section>
 
   <section id="skills" class="card section-anchor">
     <h2>{{ 'sections.technicalSkills' | translate }}</h2>
-    <ul>
-      <li *ngFor="let skill of skills">{{ skill }}</li>
-    </ul>
+    <div class="skill-chips">
+      <span class="chip" *ngFor="let chip of skillChips">{{ chip }}</span>
+    </div>
   </section>
 
   <section id="experience" class="card section-anchor">
     <h2>{{ 'sections.workHistory' | translate }}</h2>
-    <ul>
-      <li *ngFor="let role of workHistory">
-        <strong>{{ role.title }}</strong>: {{ role.description }}
-      </li>
-    </ul>
+    <div class="timeline">
+      <div class="timeline-item" *ngFor="let item of workTimeline">
+        <div class="timeline-dot"></div>
+        <div class="timeline-content">
+          <div class="timeline-header">
+            <span class="timeline-role">{{ item.role }}</span>
+            <span class="timeline-dates">{{ item.dates }}</span>
+          </div>
+          <div class="timeline-company">{{ item.company }}</div>
+          <p class="timeline-desc">{{ item.description }}</p>
+        </div>
+      </div>
+    </div>
   </section>
 
   <section id="projects" class="card section-anchor">
     <h2>{{ 'sections.featuredProjects' | translate }}</h2>
-    <ul>
-      <li *ngFor="let project of projects">
-        <strong>{{ project.title }}</strong>: {{ project.description }}
-      </li>
-    </ul>
+    <div class="timeline">
+      <div class="timeline-item" *ngFor="let item of projectTimeline">
+        <div class="timeline-dot"></div>
+        <div class="timeline-content">
+          <div class="timeline-header">
+            <span class="timeline-role">{{ item.role }}</span>
+            <span class="timeline-dates">{{ item.dates }}</span>
+          </div>
+          <div class="timeline-company">{{ item.company }}</div>
+          <p class="timeline-desc">{{ item.description }}</p>
+        </div>
+      </div>
+    </div>
   </section>
 
   <section id="education" class="card section-anchor">
@@ -86,9 +114,35 @@
 
   <section id="contact" class="card section-anchor">
     <h2>{{ 'sections.contact' | translate }}</h2>
-    <p>{{ 'contact.email' | translate }}</p>
-    <p>{{ 'contact.phone' | translate }}</p>
-    <p>{{ 'contact.location' | translate }}</p>
-    <p>{{ 'contact.linkedin' | translate }}</p>
+    <ul class="contact-list">
+      <li>
+        <svg class="contact-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <rect x="2" y="4" width="20" height="16" rx="2"/>
+          <path d="m22 7-8.97 5.7a1.94 1.94 0 0 1-2.06 0L2 7"/>
+        </svg>
+        <a href="mailto:javierl.1994@gmail.com">javierl.1994@gmail.com</a>
+      </li>
+      <li>
+        <svg class="contact-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <path d="M22 16.92v3a2 2 0 0 1-2.18 2 19.79 19.79 0 0 1-8.63-3.07A19.5 19.5 0 0 1 4.72 12a19.79 19.79 0 0 1-3.07-8.67A2 2 0 0 1 3.63 1h3a2 2 0 0 1 2 1.72 12.84 12.84 0 0 0 .7 2.81 2 2 0 0 1-.45 2.11L8.09 8.91a16 16 0 0 0 6 6l1.27-1.27a2 2 0 0 1 2.11-.45 12.84 12.84 0 0 0 2.81.7A2 2 0 0 1 22 16.92z"/>
+        </svg>
+        <a href="tel:+12499790803">(249) 979-0803</a>
+      </li>
+      <li>
+        <svg class="contact-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <path d="M20 10c0 6-8 12-8 12s-8-6-8-12a8 8 0 0 1 16 0Z"/>
+          <circle cx="12" cy="10" r="3"/>
+        </svg>
+        <span>Sudbury, ON</span>
+      </li>
+      <li>
+        <svg class="contact-icon" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+          <path d="M16 8a6 6 0 0 1 6 6v7h-4v-7a2 2 0 0 0-2-2 2 2 0 0 0-2 2v7h-4v-7a6 6 0 0 1 6-6z"/>
+          <rect x="2" y="9" width="4" height="12"/>
+          <circle cx="4" cy="4" r="2"/>
+        </svg>
+        <a href="https://linkedin.com/in/javier-alberto-lopez-bonilla-500012ba/" target="_blank" rel="noopener noreferrer">linkedin.com/in/javier-alberto-lopez-bonilla-500012ba/</a>
+      </li>
+    </ul>
   </section>
 </main>

--- a/src/app/portfolio.component.ts
+++ b/src/app/portfolio.component.ts
@@ -1,5 +1,5 @@
-import { NgFor } from '@angular/common';
-import { Component } from '@angular/core';
+import { NgFor, NgIf } from '@angular/common';
+import { AfterViewInit, Component } from '@angular/core';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 
 type Lang = 'en' | 'fr';
@@ -9,9 +9,16 @@ interface LocalizedItem {
   description: string;
 }
 
+interface TimelineItem {
+  role: string;
+  company: string;
+  dates: string;
+  description: string;
+}
+
 @Component({
   selector: 'app-root',
-  imports: [NgFor, TranslateModule],
+  imports: [NgFor, NgIf, TranslateModule],
   templateUrl: './portfolio.component.html',
   styleUrl: './portfolio.component.css',
   host: {
@@ -19,13 +26,18 @@ interface LocalizedItem {
     '[class.dark-theme]': 'isDarkTheme'
   }
 })
-export class PortfolioComponent {
+export class PortfolioComponent implements AfterViewInit {
   isDarkTheme = true;
   language: Lang = 'en';
 
   skills: string[] = [];
   workHistory: LocalizedItem[] = [];
   projects: LocalizedItem[] = [];
+
+  displayedRole = '';
+  avatarMissing = false;
+
+  private typingTimer: ReturnType<typeof setInterval> | null = null;
 
   constructor(private readonly translate: TranslateService) {
     if (typeof window !== 'undefined') {
@@ -43,9 +55,11 @@ export class PortfolioComponent {
     this.translate.setDefaultLang('en');
     this.translate.use(this.language);
     this.loadCollections();
+    this.translate.get('hero.role').subscribe(role => this.startTypingAnimation(role));
 
     this.translate.onLangChange.subscribe(() => {
       this.loadCollections();
+      this.translate.get('hero.role').subscribe(role => this.startTypingAnimation(role));
     });
   }
 
@@ -66,11 +80,84 @@ export class PortfolioComponent {
     }
   }
 
+  get workTimeline(): TimelineItem[] {
+    return this.workHistory.map(item => this.parseTimelineItem(item));
+  }
+
+  get projectTimeline(): TimelineItem[] {
+    return this.projects.map(item => this.parseTimelineItem(item));
+  }
+
+  private parseTimelineItem(item: LocalizedItem): TimelineItem {
+    const match = item.title.match(/^(.+?)\s+[—–]\s+(.+?)\s*\((.+?)\)$/);
+    if (match) {
+      return { role: match[1].trim(), company: match[2].trim(), dates: match[3].trim(), description: item.description };
+    }
+    return { role: item.title, company: '', dates: '', description: item.description };
+  }
+
+  get skillChips(): string[] {
+    return this.skills.flatMap(s => this.splitByComma(s));
+  }
+
+  private splitByComma(text: string): string[] {
+    const result: string[] = [];
+    let current = '';
+    let depth = 0;
+    for (const char of text) {
+      if (char === '(') depth++;
+      else if (char === ')') depth--;
+      if (char === ',' && depth === 0) {
+        if (current.trim()) result.push(current.trim());
+        current = '';
+      } else {
+        current += char;
+      }
+    }
+    if (current.trim()) result.push(current.trim());
+    return result;
+  }
+
   private loadCollections(): void {
     this.translate.get(['skills', 'workHistory', 'projects']).subscribe((result) => {
       this.skills = Array.isArray(result['skills']) ? result['skills'] : [];
       this.workHistory = Array.isArray(result['workHistory']) ? result['workHistory'] : [];
       this.projects = Array.isArray(result['projects']) ? result['projects'] : [];
     });
+  }
+
+  ngAfterViewInit(): void {
+    if (typeof window === 'undefined' || !('IntersectionObserver' in window)) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach(entry => {
+          if (entry.isIntersecting) {
+            entry.target.classList.add('visible');
+            observer.unobserve(entry.target);
+          }
+        });
+      },
+      { threshold: 0.08 }
+    );
+
+    document.querySelectorAll('.section-anchor').forEach(el => {
+      el.classList.add('reveal');
+      observer.observe(el);
+    });
+  }
+
+  private startTypingAnimation(text: string): void {
+    if (this.typingTimer) clearInterval(this.typingTimer);
+    this.displayedRole = '';
+    let i = 0;
+    this.typingTimer = setInterval(() => {
+      if (i < text.length) {
+        this.displayedRole += text[i++];
+      } else {
+        clearInterval(this.typingTimer!);
+        this.typingTimer = null;
+      }
+    }, 80);
   }
 }


### PR DESCRIPTION
## Summary
- **Two-column grid layout** — hero+skills, work history+projects, education+contact side by side on desktop; collapses to single column on mobile (≤768px)
- **Avatar + typewriter animation** — circular JL initials badge in hero (auto-swaps to \`public/avatar.jpg\` when added); role title types out character by character and re-triggers on language switch
- **Skill chips** — comma-separated bullet strings replaced with individual pill badges using a smart parser that preserves parenthesized groups (e.g. \`Azure serverless (Functions, Service Bus)\` stays as one chip)
- **Timeline for work history & projects** — gradient vertical line, glowing dot per entry, date badge pill, role title, and muted company/location row
- **Single-row sticky nav with brand mark** — gradient JL badge on the left, section links in the middle, EN/FR + theme toggle pinned right; no longer wraps to two rows
- **Contact section with icons** — SVG icons for email, phone, location, LinkedIn; email and phone are \`mailto:\`/\`tel:\` links, LinkedIn opens in new tab
- **Scroll-in fade animations** — \`IntersectionObserver\` adds \`reveal\` class in JS (no-JS safe: content stays visible without JS) and flips to \`visible\` as each card enters the viewport

## Test plan
- [ ] Desktop (≥1280px): verify two-column layout across all section pairs
- [ ] Mobile (≤768px): verify single-column collapse and centered avatar
- [ ] Toggle EN ↔ FR: verify typewriter re-animates with translated role title
- [ ] Toggle light/dark theme: verify all new elements respect CSS variables
- [ ] Click email, phone, LinkedIn in contact section
- [ ] Scroll down slowly and observe cards fading in

🤖 Generated with [Claude Code](https://claude.com/claude-code)